### PR TITLE
XInputProKeyboard: amend location of touchStrip

### DIFF
--- a/Packages/com.thenathannator.plasticband/PlasticBand/Devices/ProKeyboard/XInputProKeyboard.cs
+++ b/Packages/com.thenathannator.plasticband/PlasticBand/Devices/ProKeyboard/XInputProKeyboard.cs
@@ -77,15 +77,17 @@ namespace PlasticBand.Devices
         public byte velocity5;
 
         [InputControl(name = "overdrive", layout = "Button", bit = 7)]
-        // The touchstrip isn't available through XInput, but it has to be there for ProKeyboard
-        // These bits are unused, so we place it here
-        [InputControl(name = "touchStrip", layout = "Axis", format = "BIT", sizeInBits = 7)]
         public byte overdrive;
 
         // TODO: The normalization here needs verification
         [InputControl(name = "analogPedal", layout = "Axis", format = "BIT", sizeInBits = 7, parameters = "normalize,normalizeMin=1,normalizeMax=0,normalizeZero=1")]
         [InputControl(name = "digitalPedal", layout = "Button", bit = 7)]
         public byte pedal;
+
+        // Bytes after this point are not reported via XInput on Windows.
+
+        [InputControl(name = "touchStrip", layout = "Axis", format = "BIT", sizeInBits = 7)]
+        public byte touchPad;
     }
 
     [InputControlLayout(stateType = typeof(XInputProKeyboardState), displayName = "XInput Rock Band Pro Keyboard")]


### PR DESCRIPTION
The bytes representing the XInput keytar touch strip don't seem to be in the correct position, and as a result nothing is reported when touching the slider.

Sources for fix: [XInput Keytar PlasticBand Documentation](https://github.com/TheNathannator/PlasticBand/blob/main/Docs/Instruments/Pro%20Keyboard/Xbox%20360.md), and [PS3ProKeyboard.cs](https://github.com/TheNathannator/PlasticBand-Unity/blob/38fb20f6fe7bbc2884d4db847277e7bc061403f7/Packages/com.thenathannator.plasticband/PlasticBand/Devices/ProKeyboard/PS3ProKeyboard.cs#L87-L94) (which this PR now matches).

It seems like this hasn't really been a bug before the shotgun backend, as XInput on Windows doesn't include these bytes. It might be a good idea to test Windows anyway, as I'm not sure what would happen if it if tries to read bytes out of range.

Thanks!